### PR TITLE
Remove unneeded parameter determining if public ip should be created

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,6 @@ Default: `false`
 Description: The IP configuration for the Azure Bastion Host.
 - `name` - The name of the IP configuration.
 - `subnet_id` - The ID of the subnet where the Azure Bastion Host will be deployed.
-- `create_public_ip` - Specifies whether a public IP address should be created by the module. if both `create_public_ip` and `public_ip_address_id` are set, the `public_ip_address_id` will be ignored.
 - `public_ip_address_name` - The Name of the public IP address to create. Will be ignored if `public_ip_address_id` is set.
 - `public_ip_address_id` - The ID of the public IP address associated with the Azure Bastion Host.
 
@@ -193,7 +192,6 @@ Type:
 object({
     name                   = optional(string)
     subnet_id              = string
-    create_public_ip       = optional(bool, true)
     public_ip_address_name = optional(string, null)
     public_ip_address_id   = optional(string, null)
   })

--- a/examples/Basic-sku/README.md
+++ b/examples/Basic-sku/README.md
@@ -102,7 +102,6 @@ module "azure_bastion" {
     name                 = "my-ipconfig"
     subnet_id            = module.virtualnetwork.subnets["AzureBastionSubnet"].resource_id
     public_ip_address_id = azurerm_public_ip.example.id
-    create_public_ip     = false
   }
 
   tags = {

--- a/examples/Basic-sku/main.tf
+++ b/examples/Basic-sku/main.tf
@@ -96,7 +96,6 @@ module "azure_bastion" {
     name                 = "my-ipconfig"
     subnet_id            = module.virtualnetwork.subnets["AzureBastionSubnet"].resource_id
     public_ip_address_id = azurerm_public_ip.example.id
-    create_public_ip     = false
   }
 
   tags = {

--- a/examples/Premium-sku/README.md
+++ b/examples/Premium-sku/README.md
@@ -90,7 +90,6 @@ module "azure_bastion" {
   sku                 = "Premium"
   ip_configuration = {
     subnet_id        = module.virtualnetwork.subnets["AzureBastionSubnet"].resource_id
-    create_public_ip = false
   }
   ip_connect_enabled        = true
   scale_units               = 4

--- a/examples/Premium-sku/main.tf
+++ b/examples/Premium-sku/main.tf
@@ -84,7 +84,6 @@ module "azure_bastion" {
   sku                 = "Premium"
   ip_configuration = {
     subnet_id        = module.virtualnetwork.subnets["AzureBastionSubnet"].resource_id
-    create_public_ip = false
   }
   ip_connect_enabled        = true
   scale_units               = 4

--- a/examples/Standard-sku/README.md
+++ b/examples/Standard-sku/README.md
@@ -105,7 +105,6 @@ module "azure_bastion" {
     name                 = "my-ipconfig"
     subnet_id            = module.virtualnetwork.subnets["AzureBastionSubnet"].resource_id
     public_ip_address_id = azurerm_public_ip.example.id
-    create_public_ip     = false
   }
   ip_connect_enabled     = true
   scale_units            = 4

--- a/examples/Standard-sku/main.tf
+++ b/examples/Standard-sku/main.tf
@@ -99,7 +99,6 @@ module "azure_bastion" {
     name                 = "my-ipconfig"
     subnet_id            = module.virtualnetwork.subnets["AzureBastionSubnet"].resource_id
     public_ip_address_id = azurerm_public_ip.example.id
-    create_public_ip     = false
   }
   ip_connect_enabled     = true
   scale_units            = 4

--- a/main.tf
+++ b/main.tf
@@ -116,7 +116,7 @@ resource "azurerm_monitor_diagnostic_setting" "this" {
 
 
 module "public_ip_address" {
-  count               = var.ip_configuration != null ? (var.ip_configuration.create_public_ip == true ? 1 : 0) : var.sku == "Developer" ? 0 : 1
+  count               = var.ip_configuration != null ? (var.ip_configuration.public_ip_address_id == null ? 1 : 0) : var.sku == "Developer" ? 0 : 1
   source              = "Azure/avm-res-network-publicipaddress/azurerm"
   version             = "0.2.0"
   enable_telemetry    = var.enable_telemetry
@@ -137,7 +137,7 @@ resource "azurerm_management_lock" "pip" {
 }
 
 data "azurerm_public_ip" "this" {
-  count = var.ip_configuration != null ? (var.ip_configuration.create_public_ip == false && var.private_only_enabled == false ? 1 : 0) : 0
+  count = var.ip_configuration != null ? (var.ip_configuration.public_ip_address_id != null && var.private_only_enabled == false ? 1 : 0) : 0
 
   name                = split("/", var.ip_configuration.public_ip_address_id)[length(split("/", var.ip_configuration.public_ip_address_id)) - 1]
   resource_group_name = split("/", var.ip_configuration.public_ip_address_id)[4]

--- a/variables.tf
+++ b/variables.tf
@@ -42,7 +42,6 @@ variable "ip_configuration" {
   type = object({
     name                   = optional(string)
     subnet_id              = string
-    create_public_ip       = optional(bool, true)
     public_ip_address_name = optional(string, null)
     public_ip_address_id   = optional(string, null)
   })
@@ -51,7 +50,6 @@ variable "ip_configuration" {
 The IP configuration for the Azure Bastion Host.
 - `name` - The name of the IP configuration.
 - `subnet_id` - The ID of the subnet where the Azure Bastion Host will be deployed.
-- `create_public_ip` - Specifies whether a public IP address should be created by the module. if both `create_public_ip` and `public_ip_address_id` are set, the `public_ip_address_id` will be ignored.
 - `public_ip_address_name` - The Name of the public IP address to create. Will be ignored if `public_ip_address_id` is set.
 - `public_ip_address_id` - The ID of the public IP address associated with the Azure Bastion Host.
 DESCRIPTION
@@ -65,12 +63,8 @@ If you are trying to deploy basic, standard or premium SKU, make sure to provide
 ERROR
   }
   validation {
-    condition     = var.private_only_enabled == true ? (var.ip_configuration != null && (var.ip_configuration.create_public_ip == false && var.ip_configuration.public_ip_address_id == null)) : true
+    condition     = var.private_only_enabled == true ? (var.ip_configuration != null && var.ip_configuration.public_ip_address_id == null) : true
     error_message = "Public IP must not be provided when private only is enabled."
-  }
-  validation {
-    condition     = var.ip_configuration != null ? (var.private_only_enabled == false && var.ip_configuration.create_public_ip == false ? var.ip_configuration.public_ip_address_id != null : true) : true
-    error_message = "Public IP address ID must be provided when create_public_ip is set to false."
   }
 }
 


### PR DESCRIPTION
## Description

Happy to close this if it doesn't coincide with AVM design principles or codestyle, but this is an issue I saw from how someone used this module where they ended up with two created public IPs, the one they expected to be used that was passed into the module and another one because `create_public_ip = false` wasn't set

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
